### PR TITLE
Fix HTTPS security headers to resolve 'Not Secure' warnings

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,7 +16,9 @@ export default defineConfig({
     ['link', { rel: 'icon', type: 'image/x-icon', href: `${base}favicon.ico` }],
     ['link', { rel: 'shortcut icon', type: 'image/x-icon', href: `${base}favicon.ico` }],
     // Enforce HTTPS for any accidental http:// requests in content
-    ['meta', { httpEquiv: 'Content-Security-Policy', content: 'upgrade-insecure-requests' }],
+    ['meta', { httpEquiv: 'Content-Security-Policy', content: 'upgrade-insecure-requests; block-all-mixed-content' }],
+    // Additional HTTPS enforcement
+    ['meta', { httpEquiv: 'Strict-Transport-Security', content: 'max-age=31536000; includeSubDomains' }],
     // Canonical (will be updated client-side for dynamic paths)
     ['link', { rel: 'canonical', href: 'https://thetradingpal.com' }],
     // Hreflang alternates for main locales


### PR DESCRIPTION
## Summary
• Add stronger HTTPS security headers to resolve browser 'Not Secure' warnings
• Enhance Content Security Policy to block mixed content
• Add Strict Transport Security header for future HTTPS enforcement

## Changes Made
• **CSP Enhancement**: Added `block-all-mixed-content` to prevent HTTP resource loading
• **HSTS Header**: Added `Strict-Transport-Security` with 1-year max-age and subdomain inclusion
• **Browser Security**: Helps browsers enforce HTTPS-only connections

## Technical Details
These headers work together to:
1. Block any HTTP resources from loading (preventing mixed content)
2. Force browsers to use HTTPS for future visits to the domain
3. Apply HTTPS enforcement to all subdomains

## Test Plan
- [x] Verify headers are properly set in VitePress config
- [ ] Deploy and test that browser 'Not Secure' warning is resolved
- [ ] Confirm all resources load over HTTPS

🤖 Generated with [Claude Code](https://claude.ai/code)