### PR TITLE
Fix Binance Alpha article image paths

### DIFF
--- a/docs/market-analysis/binance-alpha-effect-meme-coins.md
+++ b/docs/market-analysis/binance-alpha-effect-meme-coins.md
@@ -4,13 +4,13 @@ date: 2025-09-22
 author: "Caca Lam"
 authorUrl: "https://www.linkedin.com/in/caca-lam-436780338"
 description: "An in-depth look at how the rumored 'Binance Alpha' list, on-chain data, and the power of the Binance exchange can dramatically affect the price and popularity of meme coins."
-image: "/image/binance-alpha-effect-meme-coins.jpg"
+image: "/img/binance-alpha-effect-meme-coins.jpg"
 keywords: "Binance, Binance Alpha, meme coins, on-chain"
 ---
 
 # The Binance Alpha Effect: Can an On-Chain Whisper Boost Meme Coins?
 
-![Binance Alpha Effect on Meme Coins](binance-alpha-effect-meme-coins.jpg)
+![Binance Alpha Effect on Meme Coins](/img/binance-alpha-effect-meme-coins.jpg)
 
 In the fast-paced world of cryptocurrency, everyone is looking for the next big thing. Often, this search leads to meme coins and the powerful influence of major exchanges like Binance. A popular rumor is the existence of a "Binance Alpha" list—a secret watchlist of tokens Binance might list next. This article explores the concept of Binance Alpha, how traders use on-chain data to hunt for it, and the massive impact this can have on volatile meme coins. The relationship between Binance, its potential Binance Alpha list, on-chain data, and meme coins is a fascinating topic for any crypto enthusiast.
 


### PR DESCRIPTION
Fix image path errors in Binance Alpha article that were causing VitePress build failures. Updated paths from /image/ to /img/ directory and made inline image path absolute.