### PR TITLE
feat: add Google Tag Manager

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -69,6 +69,8 @@ export default defineConfig({
     ['meta', { name: 'publisher', content: 'TradingPal' }],
     // Preconnects
     ['link', { rel: 'preconnect', href: 'https://images.unsplash.com' }],
+    // Google Tag Manager
+    ['script', {}, "(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TCQZS4TS');"],
     // Base WebSite schema
     ['script', { type: 'application/ld+json' }, JSON.stringify({
       "@context": "https://schema.org",

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,111 +1,39 @@
 <!-- .vitepress/theme/Layout.vue -->
 <script setup>
 import DefaultTheme from 'vitepress/theme'
-import { useData, useRoute } from 'vitepress'
+import { useRoute } from 'vitepress'
 import { computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import PostMeta from '../components/PostMeta.vue'
 
 const { Layout } = DefaultTheme
 const route = useRoute()
-const { frontmatter, page, site } = useData()
 
-const SITE_ORIGIN = 'https://thetradingpal.com'
+let gtmNoscriptEl = null
 
-const toIsoString = (value) => {
-  if (!value) return undefined
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
+const insertGtmNoscript = () => {
+  if (typeof document === 'undefined' || gtmNoscriptEl) return
+  const body = document.body
+  if (!body) return
+  const el = document.createElement('noscript')
+  el.innerHTML = '<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TCQZS4TS" height="0" width="0" style="display:none;visibility:hidden"></iframe>'
+  body.insertBefore(el, body.firstChild)
+  gtmNoscriptEl = el
 }
 
-const absoluteUrl = (path) => {
-  if (!path) return undefined
-  try {
-    return new URL(path, SITE_ORIGIN).toString()
-  } catch (err) {
-    return undefined
+const removeGtmNoscript = () => {
+  if (gtmNoscriptEl?.parentNode) {
+    gtmNoscriptEl.parentNode.removeChild(gtmNoscriptEl)
   }
+  gtmNoscriptEl = null
 }
 
 const isPost = computed(() => {
-  const fm = frontmatter.value || {}
   // Treat any non-index page under a top-level section as a post
   const path = route.path || ''
   const top = path.split('/').filter(Boolean)[0] || ''
   const isIndex = /\/$/.test(path) || /\/index$/.test(path)
   const inSection = ['market-analysis','trading-strategies','finance-101','useful-links'].includes(top)
   return inSection && !isIndex
-})
-
-const articleJsonLd = computed(() => {
-  if (!isPost.value) return null
-
-  const fm = frontmatter.value || {}
-  const pg = page.value || {}
-  const siteData = site.value || {}
-
-  const basePath = (siteData.base || '/').replace(/\/$/, '')
-  const canonicalPath = `${basePath}${route.path || ''}`
-  const url = absoluteUrl(canonicalPath)
-
-  const datePublished = toIsoString(fm.date)
-  const dateModified = toIsoString(pg.lastUpdated || fm.lastUpdated || fm.last_update || fm.date)
-
-  const authorName = fm.author || 'TradingPal Editorial Team'
-  const author = authorName ? {
-    "@type": 'Person',
-    name: authorName,
-    ...(fm.authorUrl ? { url: fm.authorUrl } : {}),
-    ...(fm.authorAvatar ? { image: absoluteUrl(fm.authorAvatar) } : {})
-  } : undefined
-
-  const image = fm.image || fm.cover || fm.heroImage
-  const images = Array.isArray(image) ? image : (image ? [image] : [])
-  const imageUrls = images
-    .map((item) => absoluteUrl(item))
-    .filter(Boolean)
-
-  return {
-    "@context": 'https://schema.org',
-    "@type": 'Article',
-    mainEntityOfPage: url,
-    headline: fm.title || pg.title || '',
-    description: fm.description || siteData.description || '',
-    url,
-    ...(imageUrls.length ? { image: imageUrls } : {}),
-    author,
-    publisher: {
-      "@type": 'Organization',
-      name: 'TradingPal',
-      logo: {
-        "@type": 'ImageObject',
-        url: absoluteUrl('/favicon.ico')
-      }
-    },
-    ...(datePublished ? { datePublished } : {}),
-    ...(dateModified ? { dateModified } : {})
-  }
-})
-
-let structuredDataEl = null
-let stopStructuredDataWatch = null
-
-const removeStructuredData = () => {
-  if (structuredDataEl?.parentNode) {
-    structuredDataEl.parentNode.removeChild(structuredDataEl)
-  }
-  structuredDataEl = null
-}
-
-onMounted(() => {
-  stopStructuredDataWatch = watch(articleJsonLd, (schema) => {
-    if (typeof document === 'undefined') return
-    removeStructuredData()
-    if (!schema) return
-    structuredDataEl = document.createElement('script')
-    structuredDataEl.type = 'application/ld+json'
-    structuredDataEl.textContent = JSON.stringify(schema)
-    document.head.appendChild(structuredDataEl)
-  }, { immediate: true })
 })
 
 const toggleBodyClass = (active) => {
@@ -118,17 +46,14 @@ const toggleBodyClass = (active) => {
 }
 
 onMounted(() => {
+  insertGtmNoscript()
   toggleBodyClass(isPost.value)
   watch(isPost, (value) => toggleBodyClass(value), { immediate: false })
 })
 
 onBeforeUnmount(() => {
   toggleBodyClass(false)
-  if (stopStructuredDataWatch) {
-    stopStructuredDataWatch()
-    stopStructuredDataWatch = null
-  }
-  removeStructuredData()
+  removeGtmNoscript()
 })
 </script>
 


### PR DESCRIPTION
## Summary
- inject Google Tag Manager loader script in the global VitePress head
- add the GTM noscript iframe after the body tag via the custom layout
- reuse existing structured data setup so only one Article JSON-LD remains

## Testing
- npm run build