### PR TITLE
Fix IndexNow script compatibility

### DIFF
--- a/.github/scripts/submit-indexnow.sh
+++ b/.github/scripts/submit-indexnow.sh
@@ -4,6 +4,13 @@ set -e
 # IndexNow submission script
 # Extracts URLs from sitemap and submits them to IndexNow API
 
+# Check for required tools
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed."
+    echo "Install with: apt-get install jq (Ubuntu) or brew install jq (macOS)"
+    exit 1
+fi
+
 SITEMAP_URL="https://thetradingpal.com/sitemap.xml"
 API_KEY="808a8e0f85704699a6d532f0c2fb5a4a"
 KEY_LOCATION="https://thetradingpal.com/808a8e0f85704699a6d532f0c2fb5a4a.txt"
@@ -13,7 +20,8 @@ echo "Fetching sitemap from $SITEMAP_URL..."
 SITEMAP_CONTENT=$(curl -s "$SITEMAP_URL")
 
 # Extract URLs from sitemap (handles both <loc> tags)
-URLS=$(echo "$SITEMAP_CONTENT" | grep -oP '(?<=<loc>)[^<]+' || true)
+# Using sed for better portability across systems
+URLS=$(echo "$SITEMAP_CONTENT" | sed -n 's/.*<loc>\(.*\)<\/loc>.*/\1/p' || true)
 
 if [ -z "$URLS" ]; then
   echo "No URLs found in sitemap. Submitting homepage only."
@@ -45,8 +53,8 @@ RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://api.indexnow.org/indexno
   -H "Content-Type: application/json" \
   -d "$PAYLOAD")
 
-HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-BODY=$(echo "$RESPONSE" | head -n-1)
+HTTP_CODE=$(echo "$RESPONSE" | tail -n 1)
+BODY=$(echo "$RESPONSE" | sed '$d')
 
 echo "Response Code: $HTTP_CODE"
 


### PR DESCRIPTION
## Issue
The IndexNow submission script had compatibility issues with macOS/BSD systems.

## Changes
- ✅ Replace `grep -P` with `sed` for cross-platform compatibility
- ✅ Fix `head -n-1` to use `sed '$d'` (macOS doesn't support negative line counts)
- ✅ Add `jq` dependency check

## Testing
Tested locally and confirmed working:
```
Response Code: 200
✓ Success: URLs submitted successfully to IndexNow
```

The script now works on both macOS and Linux (GitHub Actions).